### PR TITLE
Fully qualify dependency names to avoid deprecation warnings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,7 @@
-{:deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        cljfx {:mvn/version "1.7.3"}
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        cljfx/cljfx {:mvn/version "1.7.3"}
+
         cljfx/css {:mvn/version "1.1.0"}
         org.apache.commons/commons-lang3 {:mvn/version "3.10"}
         com.vladsch.flexmark/flexmark {:mvn/version "0.62.0"}
@@ -18,5 +20,5 @@
                    :extra-deps {org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}}}
            :depstar {:extra-deps {seancorfield/depstar {:mvn/version "0.2.1"}}
                      :main-opts ["-m" "hf.depstar.jar"]}
-           :deploy {:extra-deps {deps-deploy {:mvn/version "0.0.9"}}
+           :deploy {:extra-deps {deps-deploy/deps-deploy {:mvn/version "0.0.9"}}
                     :main-opts ["-m" "deps-deploy.deps-deploy" "deploy"]}}}


### PR DESCRIPTION
from Clojure tools CLI 1.10.1.590

Example:

DEPRECATED: Libs must be qualified, change deps-deploy => deps-deploy/deps-deploy (deps.edn)
DEPRECATED: Libs must be qualified, change cljfx => cljfx/cljfx (deps.edn)