### PR TITLE
Add key shortcut to clear output panel

### DIFF
--- a/src/vlaaad/reveal/output_panel.clj
+++ b/src/vlaaad/reveal/output_panel.clj
@@ -205,6 +205,9 @@
       KeyCode/F
       (cond-> this shortcut show-search)
 
+      KeyCode/D
+      (cond-> this shortcut clear-lines)
+
       this)))
 
 (defmethod event/handle ::on-key-pressed [{:keys [id fx/event]}]


### PR DESCRIPTION
fixes #12 

Hi. Thanks for the awesome app. I am trying to write log viewer for postgres (https://github.com/nenadalm/postgresql-log-viewer#postgresql-log-viewer) and currently I am investigating if it is possible to use some existing data browser as ui.

It would be nice if I could clear queries so far (say before making a http request that produces some queries) and see all queries that happened during that request. It seems that code in this pr does the trick.