### PR TITLE
[wip]: Cannot create uberjar

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,4 +32,14 @@
                    :extra-deps {org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
                                 clj-commons/pomegranate {:mvn/version "1.2.0"}}}
            :depstar {:extra-deps {seancorfield/depstar {:mvn/version "0.2.1"}}
-                     :main-opts ["-m" "hf.depstar.jar"]}}}
+                     :main-opts ["-m" "hf.depstar.jar"]}
+           :jar {:extra-deps {seancorfield/depstar {:mvn/version "2.0.193"}}
+                 :exec-fn hf.depstar/uberjar
+                 :exec-args {:jar "target/reveal.jar"
+                             :no-pom true}}
+           :uberjar {:extra-deps {seancorfield/depstar {:mvn/version "2.0.193"}}
+                     :exec-fn hf.depstar/uberjar
+                     :exec-args {:jar "target/reveal-uber.jar"
+                                 :aot true
+                                 :main-class vlaaad.reveal
+                                 :no-pom true}}}}

--- a/src/vlaaad/reveal.clj
+++ b/src/vlaaad/reveal.clj
@@ -1,6 +1,9 @@
 (ns vlaaad.reveal
   (:require [clojure.string :as str]
-            [clojure.edn :as edn]))
+            [clojure.edn :as edn]
+            [vlaaad.reveal.ext] ;; this causes uberjar creation being stuck with no cpu usage
+            )
+  (:gen-class))
 
 (defn- update-some [m k f & args]
   (let [v (get m k ::not-found)]


### PR DESCRIPTION
I was thinking about creating native image or at least uberjar of my small app (https://github.com/nenadalm/postgresql-log-viewer) but it doesn't seem to be working due to reveal.

If namespace `vlaaad.reveal.ext` is required, uberjar cannot be created (I am using the namespace to show formatted sql: https://github.com/nenadalm/postgresql-log-viewer/blob/58e39dc66c42a4ff5639ce21891617c629bb59e5/extra-src/reveal/app/reveal.clj#L12).

## code with `vlaaad.reveal.ext` require doesn't work
**uberjar creation hangs**:
```
$ clojure -X:uberjar
[main] INFO hf.depstar.uberjar - Compiling vlaaad.reveal ...
```
jar still works:
```
$ clojure -X:jar
[main] INFO hf.depstar.uberjar - Building uber jar: target/reveal.jar

$ java -jar ./target/reveal.jar -m vlaaad.reveal
Command line entry point for launching reveal repls

Available commands:
  repl          Start reveal repl that wraps clojure.main/repl
  io-prepl      Start reveal prepl bound to *in* and *out*
  remote-prepl  Start a client reveal prepl that connects to a remote prepl
  help          Display help for a specific command

Use 'clj ... help <command>' to see full description of that command
```

## code without `vlaaad.reveal.ext` require works

```
$ clojure -X:uberjar
[main] INFO hf.depstar.uberjar - Compiling vlaaad.reveal ...
[main] INFO hf.depstar.uberjar - Building uber jar: target/reveal-uber.jar

$ java -jar ./target/reveal-uber.jar 
Command line entry point for launching reveal repls

Available commands:
  repl          Start reveal repl that wraps clojure.main/repl
  io-prepl      Start reveal prepl bound to *in* and *out*
  remote-prepl  Start a client reveal prepl that connects to a remote prepl
  help          Display help for a specific command

Use 'clj ... help <command>' to see full description of that command
```