### PR TITLE
Add option to use core/eval-file metadata namespace

### DIFF
--- a/src/vlaaad/reveal/ns.clj
+++ b/src/vlaaad/reveal/ns.clj
@@ -1,5 +1,10 @@
 (ns vlaaad.reveal.ns
-  (:import [java.io FileNotFoundException]))
+  (:require [clojure.java.io :as io]
+            [clojure.tools.namespace.file :as namespace.file]
+            [clojure.tools.namespace.parse :as namespace.parse]
+            [clojure.tools.reader :as reader])
+  (:import [clojure.lang ExceptionInfo]
+           [java.io FileNotFoundException IOException]))
 
 (defmacro when-exists [ns-sym & body]
   `(try
@@ -8,3 +13,38 @@
        (require '~ns-sym))
      ~@body
      (catch FileNotFoundException _#)))
+
+(defn- try-read-file-ns-decl [source-file]
+  ;; disable reader code execution for safety - we're unlikely to need it to parse the ns decl
+  ;; note that the clojure.tools.namespace functions use reader/*read-eval*, not the *read-eval* in core
+  (binding [reader/*read-eval* false]
+    (try
+      (namespace.file/read-file-ns-decl source-file)
+      (catch ExceptionInfo e
+        (case (:ex-kind (ex-data e))
+          (:reader-error) nil ; syntax error or reader/*read-eval* violation
+          (:eof :illegal-argument) nil ; syntax error
+          (throw e)))
+      (catch IOException _
+        nil))))
+
+(defonce ^:private source-file-info-cache-atom (atom {}))
+
+(defn- source-file-info [source-file-or-path]
+  (let [source-file (io/file source-file-or-path)]
+    (when (and source-file (.isFile source-file))
+      (let [absolute-path (.getAbsolutePath source-file)
+            last-modified (.lastModified source-file)]
+        (or (when-let [source-file-info (get @source-file-info-cache-atom absolute-path)]
+              (when (= last-modified (:last-modified source-file-info))
+                source-file-info))
+            (let [ns-decl (try-read-file-ns-decl source-file)
+                  ns-symbol (some-> ns-decl namespace.parse/name-from-ns-decl)]
+              (-> (swap! source-file-info-cache-atom
+                         assoc absolute-path
+                         {:last-modified last-modified
+                          :ns-symbol ns-symbol})
+                  (get absolute-path))))))))
+
+(defn file-ns-symbol [source-file-or-path]
+  (some-> source-file-or-path source-file-info :ns-symbol))

--- a/src/vlaaad/reveal/prefs.clj
+++ b/src/vlaaad/reveal/prefs.clj
@@ -26,8 +26,11 @@
 (s/def ::theme
   #{:dark :light})
 
+(s/def ::use-eval-file-metadata-namespace
+  boolean?)
+
 (s/def ::prefs
-  (s/keys :opt-un [::font-family ::font-size ::theme]))
+  (s/keys :opt-un [::font-family ::font-size ::theme ::use-eval-file-metadata-namespace]))
 
 (def prefs
   (delay


### PR DESCRIPTION
Add a `:use-eval-file-metadata-namespace` boolean setting to prefs. If set to `true`, Reveal will try to use the `:clojure.core/eval-file` path supplied by some editors as metadata when evaluating forms. If `:clojure.core/eval-file` refers to a valid source file, Reveal will parse the namespace name from its `ns` declaration and evaluate the form inside that namespace instead of the current namespace.

This is useful when you are not using the nREPL middleware and your editor applies the `:clojure.core/eval-file` metadata to forms passed to the REPL. For example, if you use Cursive with a socket REPL.