### PR TITLE
Add action for opening source locations in configured editor

### DIFF
--- a/src/vlaaad/reveal/prefs.clj
+++ b/src/vlaaad/reveal/prefs.clj
@@ -1,7 +1,8 @@
 (ns vlaaad.reveal.prefs
   (:require [clojure.spec.alpha :as s]
             [clojure.edn :as edn]
-            [clojure.main :as m])
+            [clojure.main :as m]
+            [clojure.string :as string])
   (:import [java.net URL MalformedURLException]
            [javafx.scene.text Font]))
 
@@ -29,8 +30,13 @@
 (s/def ::theme
   #{:dark :light})
 
+(s/def ::editor
+  (s/and string?
+         #(string/includes? % "{file}")
+         #(string/includes? % "{line}")))
+
 (s/def ::prefs
-  (s/keys :opt-un [::font-family ::font-size ::formatting ::theme]))
+  (s/keys :opt-un [::font-family ::font-size ::formatting ::theme ::editor]))
 
 (def prefs
   (delay

--- a/src/vlaaad/reveal/source_location.clj
+++ b/src/vlaaad/reveal/source_location.clj
@@ -1,0 +1,143 @@
+(ns vlaaad.reveal.source-location
+  (:require [clojure.java.io :as io])
+  (:import [clojure.lang Compiler Compiler$CompilerException Namespace Var]
+           [java.io File]))
+
+(set! *warn-on-reflection* true)
+
+(defn- resolve-source-file
+  ^File [file]
+  (let [^File file (cond
+                     (nil? file) nil
+                     (instance? File file) file
+                     :else (io/file (or (io/resource file) file)))]
+    (when (and file (.isFile file))
+      (.getAbsoluteFile file))))
+
+(defn- parse-int
+  [^String string]
+  (try
+    (Integer/parseInt string)
+    (catch NumberFormatException _
+      nil)))
+
+(defn- make-source-location
+  [file line]
+  (when-some [file (resolve-source-file file)]
+    {:file file
+     :line (if (nat-int? line) line 1)}))
+
+(defn- var-source-file
+  ^File [var]
+  (resolve-source-file (:file (meta var))))
+
+(defn of-var
+  [var]
+  (let [{:keys [file line]} (meta var)]
+    (make-source-location file line)))
+
+(defn- ns-source-file
+  ^File [ns]
+  (some->> (cond
+             (instance? Namespace ns) ns
+             (symbol? ns) (find-ns ns))
+           (ns-map)
+           (some (fn [[_sym var]]
+                   (when (and (instance? Var var)
+                              (= ns (.ns ^Var var)))
+                     (var-source-file var))))))
+
+(defn of-ns
+  [ns]
+  (some-> (cond
+            (instance? Namespace ns) ns
+            (symbol? ns) (find-ns ns))
+          (ns-source-file)
+          (make-source-location 1)))
+
+(defn- symbol-source-file
+  ^File [sym]
+  (if-some [var (resolve sym)]
+    (var-source-file var)
+    (if-some [ns (or (find-ns sym)
+                     (some-> (namespace sym)
+                             (symbol)
+                             (find-ns)))]
+      (ns-source-file ns))))
+
+(defn of-symbol
+  [sym]
+  (if-some [var (resolve sym)]
+    (of-var var)
+    (of-ns sym)))
+
+(defn- demunged-name
+  ^String [^String munged-name]
+  (-> (Compiler/demunge munged-name)
+      (.replaceAll "--\\d{3,}" "")))
+
+(defn- fn-symbol
+  [fn]
+  {:pre [(ifn? fn)]}
+  (-> (class fn)
+      (.getName)
+      (demunged-name)
+      (symbol)))
+
+(defn of-fn
+  [fn]
+  (some-> (fn-symbol fn)
+          (resolve)
+          (of-var)))
+
+(defn of-stack-trace-element
+  [^StackTraceElement el]
+  (some-> (.getClassName el)
+          (demunged-name)
+          (symbol)
+          (symbol-source-file)
+          (make-source-location (.getLineNumber el))))
+
+(defn of-compiler-exception
+  [^Compiler$CompilerException e]
+  (make-source-location (.-source e) (.-line e)))
+
+(defn of-string
+  [string]
+  (when-some [[_ pathname line-number]
+              (re-find #"([^\s\"'`]+\.clj)(?:[\:\"'`]*)?(\d+)?" string)]
+    (let [file (resolve-source-file pathname)
+          line (parse-int line-number)]
+      (make-source-location file line))))
+
+(defn of-test-tree-item
+  [test-tree-item]
+  (let [name (:name test-tree-item)]
+    (when (string? name)
+      (of-symbol (symbol name)))))
+
+(defn of-value [value]
+  (cond
+    (var? value)
+    (of-var value)
+
+    (symbol? value)
+    (of-symbol value)
+
+    (string? value)
+    (of-string value)
+
+    (fn? value)
+    (of-fn value)
+
+    (instance? Namespace value)
+    (of-ns value)
+
+    (instance? StackTraceElement value)
+    (of-stack-trace-element value)
+
+    (instance? Compiler$CompilerException value)
+    (of-compiler-exception value)
+
+    (= :ctx (:type value))
+    (of-test-tree-item value)))


### PR DESCRIPTION
This PR introduces an `editor` action which will open the source location associated with the selected value in a configured editor.

The user needs to specify a shell command that will open a particular `{file}` and `{line}` in their preferred editor in prefs. Many editors provide a way to install a command-line utility for this purpose. Once installed, Reveal can be configured to use it. For example:

```clj
;; IntelliJ IDEA
{:editor "idea --line {line} {file}"}

;; Visual Studio Code
{:editor "code --goto {file}:{line}"}
```

The `editor` action will not show up unless an `:editor` command line has been configured.

Currently, the `editor` action works on `vars`, `symbols`, `strings` that appear to reference a source location, `functions`, `Namespaces`, `StackTraceElements`, `CompilerExceptions` (for syntax errors), and test runner tree items associated with a `deftest`.

It would be nice to eventually make it work on individual `(is ...)` clauses in the test runner as well, but it appears to be a non-trivial change.