### PR TITLE
Highlight the first symbol in list forms

### DIFF
--- a/src/vlaaad/reveal/stream.clj
+++ b/src/vlaaad/reveal/stream.clj
@@ -664,9 +664,13 @@
   (escaped-string k {:fill :keyword}
                   escape-layout-chars {:fill :scalar}))
 
-(defstream Symbol [sym]
-  (escaped-string sym {:fill :symbol}
-                  escape-layout-chars {:fill :scalar}))
+(defstream Symbol [sym {:keys [vlaaad.reveal.nav/key vlaaad.reveal.nav/coll]}]
+  (let [fill (if (and (= 0 key)
+                      (seq? coll))
+               :object
+               :symbol)]
+    (escaped-string sym {:fill fill}
+                    escape-layout-chars {:fill :scalar})))
 
 ;; numbers
 


### PR DESCRIPTION
This PR tweaks how list values are formatted in the output window. If the first element of a list is a `symbol`, it is highlighted to appear like a function call. This is helpful when debugging macros, etc.

## Before
<img width="670" height="438" alt="before" src="https://github.com/user-attachments/assets/4575b7e2-19f3-4987-b691-8455c69ca8bc" />

## After
<img width="670" height="438" alt="after" src="https://github.com/user-attachments/assets/def3b697-29a3-4b1b-bb77-1beed7bafde5" />
