### PR TITLE
Prettify exceptions

### DIFF
--- a/src/vlaaad/reveal/action.clj
+++ b/src/vlaaad/reveal/action.clj
@@ -123,6 +123,17 @@
          (apply diff/diff (drop 1 (second actual)))
          (diff/diff expected actual)))))
 
+(defaction ::prettify [x]
+  (cond
+    (instance? Throwable x)
+    #(stream/thrown x)
+
+    (and (map? x)
+         (vector? (:via x))
+         (vector? (:trace x))
+         (string? (:cause x)))
+    #(stream/datafied-thrown x)))
+
 (defaction ::why-is-this-boolean-red? [x]
   (when (and (boolean? x)
              (not (or (identical? Boolean/TRUE x)

--- a/src/vlaaad/reveal/prepl.clj
+++ b/src/vlaaad/reveal/prepl.clj
@@ -7,7 +7,9 @@
 (defn- prepl-output [x]
   (if (:exception x)
     (stream/as x
-      (cond-> (stream/datafied-thrown (:val x))
+      (cond-> (stream/override-style
+                (stream/datafied-thrown (:val x))
+                stream/replace-non-util-fill :error)
         (:form x)
         (as-> $ (stream/vertical
                   (stream/raw-string (:form x) {:fill :util})

--- a/src/vlaaad/reveal/repl.clj
+++ b/src/vlaaad/reveal/repl.clj
@@ -75,7 +75,9 @@
 
 (defn- wrap-caught [ui caught]
   (fn [ex]
-    (ui (stream/thrown ex))
+    (ui (stream/override-style
+          (stream/thrown ex)
+          stream/replace-non-util-fill :error))
     (caught ex)))
 
 (defn- make-tap [ui]

--- a/src/vlaaad/reveal/source_location.clj
+++ b/src/vlaaad/reveal/source_location.clj
@@ -98,6 +98,19 @@
           (symbol-source-file)
           (make-source-location (.getLineNumber el))))
 
+(defn of-datafied-stack-trace-element
+  [el]
+  (when (and (vector? el)
+             (= 4 (count el)))
+    (let [[class-name-sym _ _ line] el]
+      (when (and (symbol? class-name-sym)
+                 (integer? line))
+        (some-> (str class-name-sym)
+                (demunged-name)
+                (symbol)
+                (symbol-source-file)
+                (make-source-location line))))))
+
 (defn of-compiler-exception
   [^Compiler$CompilerException e]
   (make-source-location (.-source e) (.-line e)))
@@ -135,6 +148,9 @@
 
     (instance? StackTraceElement value)
     (of-stack-trace-element value)
+
+    (vector? value)
+    (of-datafied-stack-trace-element value)
 
     (instance? Compiler$CompilerException value)
     (of-compiler-exception value)

--- a/src/vlaaad/reveal/stream.clj
+++ b/src/vlaaad/reveal/stream.clj
@@ -1208,11 +1208,6 @@
 (ns/when-exists lambdaisland.deep-diff.diff
   (load "stream/deep_diff"))
 
-(defn- stream-diff-value [x]
-  (if (instance? Throwable x)
-    (thrown x)
-    (stream x)))
-
 (defn- style-diff-value [x fill]
   (override-style x replace-non-util-fill fill))
 
@@ -1220,13 +1215,13 @@
   (let [-sf (style-diff-value
               (horizontal
                 (raw-string "-")
-                (stream-diff-value -))
+                (stream -))
               :error)
 
         +sf (style-diff-value
               (horizontal
                 (raw-string "+")
-                (stream-diff-value +))
+                (stream +))
               :success)]
 
     (if (horizontal-args? - +)
@@ -1237,12 +1232,12 @@
   (style-diff-value
     (horizontal
       (raw-string "+")
-      (stream-diff-value +))
+      (stream +))
     :success))
 
 (defstream Deletion [{:keys [-]}]
   (style-diff-value
     (horizontal
       (raw-string "-")
-      (stream-diff-value -))
+      (stream -))
     :error))

--- a/src/vlaaad/reveal/view.clj
+++ b/src/vlaaad/reveal/view.clj
@@ -239,7 +239,9 @@
                :focus-traversable true
                :text "Loading..."}
     ::value (->desc (:value props))
-    ::exception (->desc (stream/thrown (:exception props)))))
+    ::exception (->desc (stream/override-style
+                          (stream/thrown (:exception props))
+                          stream/replace-non-util-fill :error))))
 
 (defn derefable [{:keys [derefable]}]
   {:fx/type rfx/ext-with-process


### PR DESCRIPTION
This change attempts to consolidate the functionality around stack traces so that they consistently present filtered and demunged stack trace elements when requested.

A `prettify` action can now be performed on exceptions to shorten and demunge their call stacks.

Some tweaks have also been made to `diff` output. We now keep any `:util` `:fill` values intact when we override the style to show added or removed values. Also, `diff` `Mismatch` values have been updated to respect the `:slim` `:formatting` preference.