### PR TITLE
Show type as prompt-text in popup

### DIFF
--- a/src/vlaaad/reveal/action_popup.clj
+++ b/src/vlaaad/reveal/action_popup.clj
@@ -253,6 +253,7 @@
             :refs (into {::text-field {:fx/type fx.text-field/lifecycle
                                        :text-formatter rfx/code-text-formatter
                                        :text text
+                                       :prompt-text (pr-str (type (:value annotated-value)))
                                        :on-focused-changed {::event/type ::on-text-focused
                                                             :id id}
                                        :on-key-pressed {::event/type ::on-text-key-pressed


### PR DESCRIPTION
Show the type of the selected value as prompt-text in the popup text field.

<img width="670" height="439" alt="image" src="https://github.com/user-attachments/assets/82f659c5-9d8d-4f33-8af9-c0eb6516b119" />

Not sure if this is the best place for it, but I've found that having the type of the selected value prominently displayed in the popup gives me valuable context when inspecting values.